### PR TITLE
Fix acceptable time values

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -46,12 +46,13 @@ export class AppComponent {
 
     const parsedValue = inputElement.value.match(/^\d*$/gi);
     
-    if (parsedValue === null || parsedValue[0] === "") {
+    if (parsedValue === null || parsedValue[0] === "" || parseInt(parsedValue[0]) === 0) {
       inputElement.value = String(Math.floor(this.cycleLengths[fieldName]/60));
       return;
     }
 
     this.cycleLengths[fieldName] = 60*parseInt(inputElement.value);
+    inputElement.value = String(Math.floor(this.cycleLengths[fieldName] / 60));
 
     if (!this.isRunningCycle && this.isCurrentCycle(fieldName)) {
       this.countdownValue = this.cycleLengths[fieldName];


### PR DESCRIPTION
Started checking if input value is 0, since this led to a negative and, due to the counter only stopping when reaching zero, an endless countdown.

Also started converting the input value back into the input field value to avoid displaying valid, but confusing units, such as "0012".